### PR TITLE
[DEV] Auto Complete

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -6,6 +6,24 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.ExportCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.HistoryCommand;
+import seedu.address.logic.commands.ImportCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.RedoCommand;
+import seedu.address.logic.commands.RemarkCommand;
+import seedu.address.logic.commands.SearchCommand;
+import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.commands.UndoCommand;
+
 /**
  * Helper functions for handling strings.
  */
@@ -76,5 +94,28 @@ public class StringUtil {
      */
     public static boolean caseInsensitiveContains(String detail, String keyphrase) {
         return detail.toLowerCase().contains(keyphrase.toLowerCase());
+    }
+
+    /**
+     * Returns the command words in the program as an Array.
+     */
+    public static String[] getSystemCommandWords() {
+        return new String[]{AddCommand.COMMAND_WORD,
+                            ClearCommand.COMMAND_WORD,
+                            DeleteCommand.COMMAND_WORD,
+                            EditCommand.COMMAND_WORD,
+                            ExitCommand.COMMAND_WORD,
+                            ExportCommand.COMMAND_WORD,
+                            FindCommand.COMMAND_WORD,
+                            HelpCommand.COMMAND_WORD,
+                            HistoryCommand.COMMAND_WORD,
+                            ImportCommand.COMMAND_WORD,
+                            ListCommand.COMMAND_WORD,
+                            RedoCommand.COMMAND_WORD,
+                            RemarkCommand.COMMAND_WORD,
+                            SearchCommand.COMMAND_WORD,
+                            SelectCommand.COMMAND_WORD,
+                            SortCommand.COMMAND_WORD,
+                            UndoCommand.COMMAND_WORD};
     }
 }

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -12,7 +12,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE_STRING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_STRING;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -251,28 +250,22 @@ public class AutoComplete {
         if (argList.isEmpty()) {
             return prefix.getPrefix();
         }
-        List<Optional> arg = new ArrayList<>();
+        Optional<String> firstArg = Optional.of(argList.get(0));
         switch (prefix.getPrefix()) {
         case PREFIX_ADDRESS_STRING:
-            arg.add(ParserUtil.parseAddress(Optional.of(argList.get(0))));
-            break;
+            return prefix.getPrefix() + ParserUtil.parseAddress(firstArg).map(p -> p.value).orElse("");
         case PREFIX_EMAIL_STRING:
-            arg.add(ParserUtil.parseEmail(Optional.of(argList.get(0))));
-            break;
+            return prefix.getPrefix() + ParserUtil.parseEmail(firstArg).map(p -> p.value).orElse("");
         case PREFIX_NAME_STRING:
-            arg.add(ParserUtil.parseName(Optional.of(argList.get(0))));
-            break;
+            return prefix.getPrefix() + ParserUtil.parseName(firstArg).map(p -> p.fullName).orElse("");
         case PREFIX_PHONE_STRING:
-            arg.add(ParserUtil.parsePhone(Optional.of(argList.get(0))));
-            break;
+            return prefix.getPrefix() + ParserUtil.parsePhone(firstArg).map(p -> p.value).orElse("");
         case PREFIX_TAG_STRING:
-            arg = ParserUtil.parseTags(argList).stream().map(Optional::of).collect(Collectors.toList());
-            break;
+            return ParserUtil.parseTags(argList).stream().map(p -> (prefix + p.tagName))
+                .collect(Collectors.joining(" "));
         default:
-            assert false : "not possible";
+            return prefix.getPrefix();
         }
-        return prefix + arg.stream().filter(Optional::isPresent).map(Optional::get).map(Object::toString)
-            .collect(Collectors.joining(" " + prefix.getPrefix()));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -120,7 +120,7 @@ public class AutoComplete {
      * Auto-completes delete command.
      */
     public static String deleteCommandAutoComplete(String args) {
-        return DeleteCommand.COMMAND_WORD +  " ";
+        return DeleteCommand.COMMAND_WORD +  " " + formatSingleIndexString(args);
     }
 
     /**
@@ -131,17 +131,16 @@ public class AutoComplete {
             ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
         String indexString = argMultimap.getPreamble().trim();
-        Index index;
+        Index index = null;
         try {
             index = ParserUtil.parseIndex(indexString);
         } catch (IllegalValueException ive) {
-            indexString = "";
-            index = null;
+            indexString = formatSingleIndexString(indexString);
         }
 
         // if the index is invalid
         if (index == null) {
-            return EditCommand.COMMAND_WORD + " ";
+            return EditCommand.COMMAND_WORD + " " + indexString + " ";
         }
 
         // auto fill all fields
@@ -194,7 +193,7 @@ public class AutoComplete {
      * Auto-completes select command.
      */
     public static String selectCommandAutoComplete(String args) {
-        return SelectCommand.COMMAND_WORD +  " ";
+        return SelectCommand.COMMAND_WORD +  " " + formatSingleIndexString(args);
     }
 
     /**
@@ -297,6 +296,13 @@ public class AutoComplete {
         default:
             return "";
         }
+    }
+
+    /**
+     * Formats the argument into all-digit form.
+     */
+    private static String formatSingleIndexString(String arg) {
+        return arg.replaceAll("\\D", "");
     }
 
 }

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -137,12 +137,17 @@ public class AutoComplete {
         }
 
         // auto fill all fields
-        ReadOnlyPerson person = filteredPersonList.get(index.getZeroBased());
-        String prefixWithArgs = formatPrefixWithArgs(argMultimap, PREFIX_NAME, person) + " "
-            + formatPrefixWithArgs(argMultimap, PREFIX_PHONE, person) + " "
-            + formatPrefixWithArgs(argMultimap, PREFIX_EMAIL, person) + " "
-            + formatPrefixWithArgs(argMultimap, PREFIX_ADDRESS, person) + " "
-            + formatPrefixWithArgs(argMultimap, PREFIX_TAG, person);
+        String prefixWithArgs;
+        try {
+            ReadOnlyPerson person = filteredPersonList.get(index.getZeroBased());
+            prefixWithArgs = formatPrefixWithArgs(argMultimap, PREFIX_NAME, person) + " "
+                + formatPrefixWithArgs(argMultimap, PREFIX_PHONE, person) + " "
+                + formatPrefixWithArgs(argMultimap, PREFIX_EMAIL, person) + " "
+                + formatPrefixWithArgs(argMultimap, PREFIX_ADDRESS, person) + " "
+                + formatPrefixWithArgs(argMultimap, PREFIX_TAG, person);
+        } catch (IndexOutOfBoundsException e) {
+            prefixWithArgs = "";
+        }
 
         return EditCommand.COMMAND_WORD + " " + indexString +  " " + prefixWithArgs;
     }

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -173,7 +173,7 @@ public class AutoComplete {
      * Auto-completes import command.
      */
     public static String importCommandAutoComplete(String args) {
-        return " ";
+        return ImportCommand.COMMAND_WORD + " " + args.trim();
     }
 
     /**

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -220,7 +220,16 @@ public class AutoComplete {
      * Auto-completes sort command.
      */
     public static String sortCommandAutoComplete(String args) {
-        return " ";
+        StringBuilder formattedArg = new StringBuilder();
+        if (args.contains(PREFIX_NAME_STRING)) {
+            formattedArg.append(PREFIX_NAME_STRING);
+        } else if (args.contains(PREFIX_PHONE_STRING)) {
+            formattedArg.append(PREFIX_PHONE_STRING);
+        }
+        if (args.contains("reverse")) {
+            formattedArg.append(" ").append("reverse");
+        }
+        return SortCommand.COMMAND_WORD + " " + formattedArg.toString();
     }
 
     /**

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -117,48 +117,6 @@ public class AutoComplete {
     }
 
     /**
-     * Formats the arguments into " PREFIX/ARGS" form.
-     */
-    private static String formatPrefixWithArgs(ArgumentMultimap argMultimap, final Prefix prefix) {
-        try {
-            return parseArgOfPrefix(argMultimap.getAllValues(prefix), prefix);
-        } catch (IllegalValueException ive) {
-            return prefix.getPrefix();
-        }
-    }
-
-    /**
-     * Tests whether the argument is valid for certain {@code Prefix}.
-     */
-    private static String parseArgOfPrefix(List<String> argList, Prefix prefix) throws IllegalValueException {
-        if (argList.isEmpty()) {
-            return prefix.getPrefix();
-        }
-        List<Optional> arg = new ArrayList<>();
-        switch (prefix.getPrefix()) {
-        case PREFIX_ADDRESS_STRING:
-            arg.add(ParserUtil.parseAddress(Optional.of(argList.get(0))));
-            break;
-        case PREFIX_EMAIL_STRING:
-            arg.add(ParserUtil.parseEmail(Optional.of(argList.get(0))));
-            break;
-        case PREFIX_NAME_STRING:
-            arg.add(ParserUtil.parseName(Optional.of(argList.get(0))));
-            break;
-        case PREFIX_PHONE_STRING:
-            arg.add(ParserUtil.parsePhone(Optional.of(argList.get(0))));
-            break;
-        case PREFIX_TAG_STRING:
-            arg = ParserUtil.parseTags(argList).stream().map(Optional::of).collect(Collectors.toList());
-            break;
-        default:
-            assert false : "not possible";
-        }
-        return prefix + arg.stream().filter(Optional::isPresent).map(Optional::get).map(Object::toString)
-            .collect(Collectors.joining(" " + prefix.getPrefix()));
-    }
-
-    /**
      * Auto-completes delete command.
      */
     public static String deleteCommandAutoComplete(String args) {
@@ -195,45 +153,6 @@ public class AutoComplete {
             + formatPrefixWithArgs(argMultimap, PREFIX_TAG, person);
 
         return EditCommand.COMMAND_WORD + " " + indexString +  " " + prefixWithArgs;
-    }
-
-    /**
-     * Formats the argument into " PREFIX/ARGS" form. If the {@code ArgumentMultimap} does not contain the field,
-     * replace the argument with {@code ReadOnlyPerson}'s corresponding field.
-     */
-    private static String formatPrefixWithArgs(ArgumentMultimap argMultimap, Prefix prefix, ReadOnlyPerson person) {
-        String prefixWithArgs = formatPrefixWithArgs(argMultimap, prefix);
-        if (prefixWithArgs.equals(prefix.getPrefix())) { // no input, read field info from person
-            prefixWithArgs += getPersonFieldOfPrefix(person, prefix);
-        }
-        if (prefix.equals(PREFIX_TAG)) {
-            // insert tag prefix into each tag
-            prefixWithArgs = prefixWithArgs.replace(" ", " " + PREFIX_TAG_STRING);
-        }
-        return prefixWithArgs;
-    }
-
-    /**
-     * @return the corresponding field of a {@code ReadOnlyPerson} based on a {@code Prefix}.
-     */
-    private static String getPersonFieldOfPrefix(ReadOnlyPerson person, Prefix prefix) {
-        requireNonNull(person);
-        requireNonNull(prefix);
-
-        switch (prefix.getPrefix()) {
-        case PREFIX_NAME_STRING:
-            return person.getName().fullName;
-        case PREFIX_PHONE_STRING:
-            return person.getPhone().value;
-        case PREFIX_EMAIL_STRING:
-            return person.getEmail().value;
-        case PREFIX_ADDRESS_STRING:
-            return person.getAddress().value;
-        case PREFIX_TAG_STRING:
-            return person.getTags().stream().map(Tag::toString).collect(Collectors.joining(" "));
-        default:
-            return "";
-        }
     }
 
     /**
@@ -297,6 +216,87 @@ public class AutoComplete {
      */
     public static String unknownCommandAutoComplete(String command, String args) {
         return " ";
+    }
+
+    /**
+     * Formats the arguments into " PREFIX/ARGS" form.
+     */
+    private static String formatPrefixWithArgs(ArgumentMultimap argMultimap, final Prefix prefix) {
+        try {
+            return parseArgOfPrefix(argMultimap.getAllValues(prefix), prefix);
+        } catch (IllegalValueException ive) {
+            return prefix.getPrefix();
+        }
+    }
+
+    /**
+     * Formats the argument into " PREFIX/ARGS" form. If the {@code ArgumentMultimap} does not contain the field,
+     * replace the argument with {@code ReadOnlyPerson}'s corresponding field.
+     */
+    private static String formatPrefixWithArgs(ArgumentMultimap argMultimap, Prefix prefix, ReadOnlyPerson person) {
+        String prefixWithArgs = formatPrefixWithArgs(argMultimap, prefix);
+        if (prefixWithArgs.equals(prefix.getPrefix())) { // no input, read field info from person
+            prefixWithArgs += getPersonFieldOfPrefix(person, prefix);
+        }
+        if (prefix.equals(PREFIX_TAG)) {
+            // insert tag prefix into each tag
+            prefixWithArgs = prefixWithArgs.replace(" ", " " + PREFIX_TAG_STRING);
+        }
+        return prefixWithArgs;
+    }
+
+    /**
+     * Tests whether the argument is valid for certain {@code Prefix}.
+     */
+    private static String parseArgOfPrefix(List<String> argList, Prefix prefix) throws IllegalValueException {
+        if (argList.isEmpty()) {
+            return prefix.getPrefix();
+        }
+        List<Optional> arg = new ArrayList<>();
+        switch (prefix.getPrefix()) {
+        case PREFIX_ADDRESS_STRING:
+            arg.add(ParserUtil.parseAddress(Optional.of(argList.get(0))));
+            break;
+        case PREFIX_EMAIL_STRING:
+            arg.add(ParserUtil.parseEmail(Optional.of(argList.get(0))));
+            break;
+        case PREFIX_NAME_STRING:
+            arg.add(ParserUtil.parseName(Optional.of(argList.get(0))));
+            break;
+        case PREFIX_PHONE_STRING:
+            arg.add(ParserUtil.parsePhone(Optional.of(argList.get(0))));
+            break;
+        case PREFIX_TAG_STRING:
+            arg = ParserUtil.parseTags(argList).stream().map(Optional::of).collect(Collectors.toList());
+            break;
+        default:
+            assert false : "not possible";
+        }
+        return prefix + arg.stream().filter(Optional::isPresent).map(Optional::get).map(Object::toString)
+            .collect(Collectors.joining(" " + prefix.getPrefix()));
+    }
+
+    /**
+     * @return the corresponding field of a {@code ReadOnlyPerson} based on a {@code Prefix}.
+     */
+    private static String getPersonFieldOfPrefix(ReadOnlyPerson person, Prefix prefix) {
+        requireNonNull(person);
+        requireNonNull(prefix);
+
+        switch (prefix.getPrefix()) {
+        case PREFIX_NAME_STRING:
+            return person.getName().fullName;
+        case PREFIX_PHONE_STRING:
+            return person.getPhone().value;
+        case PREFIX_EMAIL_STRING:
+            return person.getEmail().value;
+        case PREFIX_ADDRESS_STRING:
+            return person.getAddress().value;
+        case PREFIX_TAG_STRING:
+            return person.getTags().stream().map(Tag::toString).collect(Collectors.joining(" "));
+        default:
+            return "";
+        }
     }
 
 }

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -42,7 +42,7 @@ public class AutoComplete {
     /**
      *
      */
-    public String autoComplete(String userInput) {
+    public static String autoComplete(String userInput) {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             return unknownCommandAutoComplete(userInput);
@@ -123,7 +123,7 @@ public class AutoComplete {
     /**
      * Auto-completes the prefix field that is not entered.
      */
-    public String addCommandAutoComplete(String args) {
+    public static String addCommandAutoComplete(String args) {
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
         return AddCommand.COMMAND_WORD
@@ -137,7 +137,7 @@ public class AutoComplete {
     /**
      * Formats the arguments into " PREFIX/ARGS" form.
      */
-    private String formatPrefixWithArgs(ArgumentMultimap argMultimap, final Prefix prefix) {
+    private static String formatPrefixWithArgs(ArgumentMultimap argMultimap, final Prefix prefix) {
         String arg = "";
         List<String> argList = argMultimap.getAllValues(prefix);
         if (!argList.isEmpty()) {
@@ -149,77 +149,77 @@ public class AutoComplete {
     /**
      * Formats the arguments into " PREFIX/ARGS" form.
      */
-    public String deleteCommandAutoComplete(String args) {
+    public static String deleteCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
      * Formats the arguments into " PREFIX/ARGS" form.
      */
-    public String editCommandAutoComplete(String args) {
+    public static String editCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
      * Formats the arguments into " PREFIX/ARGS" form.
      */
-    public String exportCommandAutoComplete(String args) {
+    public static String exportCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
      * Formats the arguments into " PREFIX/ARGS" form.
      */
-    public String findCommandAutoComplete(String args) {
+    public static String findCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
      * Formats the arguments into " PREFIX/ARGS" form.
      */
-    public String importCommandAutoComplete(String args) {
+    public static String importCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
      * Formats the arguments into " PREFIX/ARGS" form.
      */
-    public String remarkCommandAutoComplete(String args) {
+    public static String remarkCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
      * Formats the arguments into " PREFIX/ARGS" form.
      */
-    public String searchCommandAutoComplete(String args) {
+    public static String searchCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
      * Formats the arguments into " PREFIX/ARGS" form.
      */
-    public String selectCommandAutoComplete(String args) {
+    public static String selectCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
      * Formats the arguments into " PREFIX/ARGS" form.
      */
-    public String sortCommandAutoComplete(String args) {
+    public static String sortCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
      * Formats the arguments into " PREFIX/ARGS" form.
      */
-    public String unknownCommandAutoComplete(String args) {
+    public static String unknownCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
      * Formats the arguments into " PREFIX/ARGS" form.
      */
-    public String unknownCommandAutoComplete(String command, String args) {
+    public static String unknownCommandAutoComplete(String command, String args) {
         return " ";
     }
 

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -226,8 +226,13 @@ public class AutoComplete {
     /**
      * Auto-completes unknown command without arguments.
      */
-    public static String unknownCommandAutoComplete(String args) {
-        return " ";
+    public static String unknownCommandAutoComplete(String input) {
+        String trimmedInput = input.trim();
+        if (trimmedInput.isEmpty()) {
+            return "";
+        } else {
+            return unknownCommandAutoComplete(trimmedInput);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -38,7 +38,6 @@ import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.Prefix;
-import seedu.address.model.Model;
 import seedu.address.model.person.ReadOnlyPerson;
 
 /**
@@ -51,7 +50,7 @@ public class AutoComplete {
     /**
      * Auto-completes the input String.
      */
-    public static String autoComplete(String userInput, Model model) {
+    public static String autoComplete(String userInput, List<ReadOnlyPerson> filteredPersonList) {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             return unknownCommandAutoComplete(userInput);
@@ -67,7 +66,7 @@ public class AutoComplete {
 
         case EditCommand.COMMAND_WORD:
         case EditCommand.COMMAND_ALIAS:
-            return editCommandAutoComplete(arguments, model);
+            return editCommandAutoComplete(arguments, filteredPersonList);
 
         case SelectCommand.COMMAND_WORD:
         case SelectCommand.COMMAND_ALIAS:
@@ -79,7 +78,7 @@ public class AutoComplete {
 
         case RemarkCommand.COMMAND_WORD:
         case RemarkCommand.COMMAND_ALIAS:
-            return remarkCommandAutoComplete(arguments, model);
+            return remarkCommandAutoComplete(arguments, filteredPersonList);
 
         case SortCommand.COMMAND_WORD:
             return sortCommandAutoComplete(arguments);
@@ -120,7 +119,7 @@ public class AutoComplete {
     /**
      * Auto-completes edit command.
      */
-    public static String editCommandAutoComplete(String args, Model model) {
+    public static String editCommandAutoComplete(String args, List<ReadOnlyPerson> filteredPersonList) {
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
@@ -138,7 +137,7 @@ public class AutoComplete {
         }
 
         // auto fill all fields
-        ReadOnlyPerson person = model.getFilteredPersonList().get(index.getZeroBased());
+        ReadOnlyPerson person = filteredPersonList.get(index.getZeroBased());
         String prefixWithArgs = formatPrefixWithArgs(argMultimap, PREFIX_NAME, person) + " "
             + formatPrefixWithArgs(argMultimap, PREFIX_PHONE, person) + " "
             + formatPrefixWithArgs(argMultimap, PREFIX_EMAIL, person) + " "
@@ -186,7 +185,7 @@ public class AutoComplete {
     /**
      * Auto-completes remark command.
      */
-    public static String remarkCommandAutoComplete(String args, Model model) {
+    public static String remarkCommandAutoComplete(String args, List<ReadOnlyPerson> filteredPersonList) {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_REMARK);
 
         String indexString = argMultimap.getPreamble().trim();
@@ -203,7 +202,7 @@ public class AutoComplete {
         }
 
         // auto fill remark field
-        ReadOnlyPerson person = model.getFilteredPersonList().get(index.getZeroBased());
+        ReadOnlyPerson person = filteredPersonList.get(index.getZeroBased());
         String prefixWithArgs = formatPrefixWithArgs(argMultimap, PREFIX_REMARK, person);
 
         return RemarkCommand.COMMAND_WORD + " " + indexString +  " " + prefixWithArgs;

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -106,11 +106,11 @@ public class AutoComplete {
     public static String addCommandAutoComplete(String args) {
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
-        return AddCommand.COMMAND_WORD
-            + formatPrefixWithArgs(argMultimap, PREFIX_NAME)
-            + formatPrefixWithArgs(argMultimap, PREFIX_PHONE)
-            + formatPrefixWithArgs(argMultimap, PREFIX_EMAIL)
-            + formatPrefixWithArgs(argMultimap, PREFIX_ADDRESS)
+        return AddCommand.COMMAND_WORD + " "
+            + formatPrefixWithArgs(argMultimap, PREFIX_NAME) + " "
+            + formatPrefixWithArgs(argMultimap, PREFIX_PHONE) + " "
+            + formatPrefixWithArgs(argMultimap, PREFIX_EMAIL) + " "
+            + formatPrefixWithArgs(argMultimap, PREFIX_ADDRESS) + " "
             + formatPrefixWithArgs(argMultimap, PREFIX_TAG);
     }
 
@@ -123,7 +123,7 @@ public class AutoComplete {
         if (!argList.isEmpty()) {
             arg = argList.stream().collect(Collectors.joining(" " + prefix.getPrefix()));
         }
-        return " " + prefix + arg;
+        return prefix + arg;
     }
 
     /**
@@ -176,7 +176,7 @@ public class AutoComplete {
         }
         if (prefix.equals(PREFIX_TAG)) {
             // insert tag prefix into each tag
-            prefixWithArgs = " " + prefixWithArgs.trim().replace(" ", " " + PREFIX_TAG_STRING);
+            prefixWithArgs = prefixWithArgs.replace(" ", " " + PREFIX_TAG_STRING);
         }
         return prefixWithArgs;
     }

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -238,12 +238,14 @@ public class AutoComplete {
         if (prefixMatch.size() == 1) { // only prefix-match
             return prefixMatch.get(0) + " " + args.trim();
         } else if (prefixMatch.size() > 1) { // multiple prefix-matches
+            prefixMatch.sort(String::compareTo);
             return promptForPossibleCommand(prefixMatch);
         } else { // no prefix-match
             List<String> fuzzyMatch = fuzzyMatches(getSystemCommandWords(), command);
             if (fuzzyMatch.isEmpty()) {
                 return "";
             }
+            fuzzyMatch.sort(String::compareTo);
             return promptForPossibleCommand(fuzzyMatch);
         }
     }
@@ -359,7 +361,7 @@ public class AutoComplete {
      */
     private static List<String> fuzzyMatches(String[] tests, String tester) {
         HashSet<String> bestMatchesSet = new HashSet<>();
-        bestMatchesSet.addAll(Arrays.stream(tests).filter(p -> levenshteinDistance(tester, p) > (p.length() / 2))
+        bestMatchesSet.addAll(Arrays.stream(tests).filter(p -> levenshteinDistance(tester, p) <= (p.length() / 2))
             .collect(Collectors.toList()));
         List<String> bestMatches = new ArrayList<>();
         bestMatches.addAll(bestMatchesSet);

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -163,7 +163,7 @@ public class AutoComplete {
         } else { // try to find the index part and file part
             int possibleDelimiterIndex = Math.max(args.lastIndexOf(' '), args.lastIndexOf(','));
             possibleIndexListString = args.substring(0, possibleDelimiterIndex);
-            possibleFilePath = args.substring(possibleDelimiterIndex);
+            possibleFilePath = args.substring(possibleDelimiterIndex + 1);
         }
 
         // format Index List

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -98,7 +98,7 @@ public class AutoComplete {
     /**
      * Auto-completes the prefix field that is not entered.
      */
-    public static String addCommandAutoComplete(String args) {
+    private static String addCommandAutoComplete(String args) {
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
         return AddCommand.COMMAND_WORD + " "
@@ -112,14 +112,14 @@ public class AutoComplete {
     /**
      * Auto-completes delete command.
      */
-    public static String deleteCommandAutoComplete(String args) {
+    private static String deleteCommandAutoComplete(String args) {
         return DeleteCommand.COMMAND_WORD +  " " + formatSingleIndexString(args);
     }
 
     /**
      * Auto-completes edit command.
      */
-    public static String editCommandAutoComplete(String args, List<ReadOnlyPerson> filteredPersonList) {
+    private static String editCommandAutoComplete(String args, List<ReadOnlyPerson> filteredPersonList) {
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
@@ -152,7 +152,7 @@ public class AutoComplete {
     /**
      * Auto-completes export command.
      */
-    public static String exportCommandAutoComplete(String args) {
+    private static String exportCommandAutoComplete(String args) {
         Pattern exportPattern = Pattern.compile("(?<possibleIndexList>.[^;]);(?<possibleFilePath>.*)");
         Matcher matcher = exportPattern.matcher(args);
 
@@ -180,14 +180,14 @@ public class AutoComplete {
     /**
      * Auto-completes import command.
      */
-    public static String importCommandAutoComplete(String args) {
+    private static String importCommandAutoComplete(String args) {
         return ImportCommand.COMMAND_WORD + " " + args.trim();
     }
 
     /**
      * Auto-completes remark command.
      */
-    public static String remarkCommandAutoComplete(String args, List<ReadOnlyPerson> filteredPersonList) {
+    private static String remarkCommandAutoComplete(String args, List<ReadOnlyPerson> filteredPersonList) {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_REMARK);
 
         String indexString = argMultimap.getPreamble().trim();
@@ -213,14 +213,14 @@ public class AutoComplete {
     /**
      * Auto-completes select command.
      */
-    public static String selectCommandAutoComplete(String args) {
+    private static String selectCommandAutoComplete(String args) {
         return SelectCommand.COMMAND_WORD +  " " + formatSingleIndexString(args);
     }
 
     /**
      * Auto-completes sort command.
      */
-    public static String sortCommandAutoComplete(String args) {
+    private static String sortCommandAutoComplete(String args) {
         StringBuilder formattedArg = new StringBuilder();
         if (args.contains(PREFIX_NAME_STRING)) {
             formattedArg.append(PREFIX_NAME_STRING);
@@ -236,7 +236,7 @@ public class AutoComplete {
     /**
      * Auto-completes unknown command without arguments.
      */
-    public static String unknownCommandAutoComplete(String input) {
+    private static String unknownCommandAutoComplete(String input) {
         String trimmedInput = input.trim();
         if (trimmedInput.isEmpty()) {
             return "";
@@ -248,7 +248,7 @@ public class AutoComplete {
     /**
      * Auto-completes unknown command.
      */
-    public static String unknownCommandAutoComplete(String command, String args) {
+    private static String unknownCommandAutoComplete(String command, String args) {
         List<String> prefixMatch = prefixMatch(getSystemCommandWords(), command);
         if (prefixMatch.size() == 1) { // only prefix-match
             return prefixMatch.get(0) + " " + args.trim();

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -256,7 +256,7 @@ public class AutoComplete {
         } else { // no prefix-match
             List<String> fuzzyMatch = fuzzyMatches(getSystemCommandWords(), command);
             if (fuzzyMatch.isEmpty()) {
-                return "";
+                return command + args;
             }
             fuzzyMatch.sort(String::compareTo);
             return promptForPossibleCommand(fuzzyMatch);

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -57,7 +57,7 @@ public class AutoComplete {
             return unknownCommandAutoComplete(userInput);
         }
 
-        final String commandWord = matcher.group("commandWord");
+        final String commandWord = matcher.group("commandWord").toLowerCase();
         final String arguments = matcher.group("arguments");
         switch (commandWord) {
 

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -152,7 +152,28 @@ public class AutoComplete {
      * Auto-completes export command.
      */
     public static String exportCommandAutoComplete(String args) {
-        return " ";
+        Pattern exportPattern = Pattern.compile("(?<possibleIndexList>.[^;]);(?<possibleFilePath>.*)");
+        Matcher matcher = exportPattern.matcher(args);
+
+        String possibleIndexListString = "";
+        String possibleFilePath = "";
+        if (matcher.matches()) { // contains delimiter ";"
+            possibleIndexListString = matcher.group("possibleIndexList");
+            possibleFilePath = matcher.group("possibleFilePath");
+        } else { // try to find the index part and file part
+            int possibleDelimiterIndex = Math.max(args.lastIndexOf(' '), args.lastIndexOf(','));
+            possibleIndexListString = args.substring(0, possibleDelimiterIndex);
+            possibleFilePath = args.substring(possibleDelimiterIndex);
+        }
+
+        // format Index List
+        possibleIndexListString = Arrays.stream(possibleIndexListString.split("(\\s)+|(,)+"))
+            .map(AutoComplete::formatSingleIndexString).filter(p -> !p.isEmpty()).collect(Collectors.joining(", "));
+
+        // format file path
+        possibleFilePath = possibleFilePath.trim();
+
+        return ExportCommand.COMMAND_WORD + " " + possibleIndexListString + "; " + possibleFilePath;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -205,7 +205,7 @@ public class AutoComplete {
      * Auto-completes search command.
      */
     public static String searchCommandAutoComplete(String args) {
-        return " ";
+        return SearchCommand.COMMAND_WORD + " ";
     }
 
     /**

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -338,7 +338,7 @@ public class AutoComplete {
      * Returns the suggested commands.
      */
     private static String promptForPossibleCommand(List<String> possibleCommands) {
-        return "";
+        return "Do you mean: " + possibleCommands.stream().collect(Collectors.joining(" or ")) + " ?";
     }
 
     /**
@@ -346,7 +346,7 @@ public class AutoComplete {
      */
     private static List<String> prefixMatch(String[] tests, String tester) {
         HashSet<String> prefixMatchesSet = new HashSet<>();
-        Pattern prefixPattern = Pattern.compile("^" + tester + "*$");
+        Pattern prefixPattern = Pattern.compile("^" + tester + ".*$");
         prefixMatchesSet.addAll(Arrays.stream(tests).filter(p -> prefixPattern.matcher(p).matches())
             .collect(Collectors.toList()));
         List<String> prefixMatches = new ArrayList<>();

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -1,6 +1,7 @@
 package seedu.address.logic;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.StringUtil.getSystemCommandWords;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS_STRING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -26,7 +27,6 @@ import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -238,7 +238,18 @@ public class AutoComplete {
      * Auto-completes unknown command.
      */
     public static String unknownCommandAutoComplete(String command, String args) {
-        return " ";
+        List<String> prefixMatch = prefixMatch(getSystemCommandWords(), command);
+        if (prefixMatch.size() == 1) { // only prefix-match
+            return prefixMatch.get(0) + " " + args.trim();
+        } else if (prefixMatch.size() > 1) { // multiple prefix-matches
+            return promptForPossibleCommand(prefixMatch);
+        } else { // no prefix-match
+            List<String> fuzzyMatch = fuzzyMatches(getSystemCommandWords(), command);
+            if (fuzzyMatch.isEmpty()) {
+                return "";
+            }
+            return promptForPossibleCommand(fuzzyMatch);
+        }
     }
 
     /**
@@ -328,6 +339,13 @@ public class AutoComplete {
     }
 
     /**
+     * Returns the suggested commands.
+     */
+    private static String promptForPossibleCommand(List<String> possibleCommands) {
+        return "";
+    }
+
+    /**
      * Finds all test in array that have prefix of tester and returns the result as a List.
      */
     private static List<String> prefixMatch(String[] tests, String tester) {
@@ -343,7 +361,7 @@ public class AutoComplete {
     /**
      *
      */
-    private static List<String> getBestMatches(String[] tests, String tester) {
+    private static List<String> fuzzyMatches(String[] tests, String tester) {
         HashSet<String> bestMatchesSet = new HashSet<>();
         int bestMatchScore = tester.length() + 1;
         for (String test : tests) {

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -9,6 +9,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME_STRING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE_STRING;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK_STRING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_STRING;
 
@@ -76,7 +78,7 @@ public class AutoComplete {
 
         case RemarkCommand.COMMAND_WORD:
         case RemarkCommand.COMMAND_ALIAS:
-            return remarkCommandAutoComplete(arguments);
+            return remarkCommandAutoComplete(arguments, model);
 
         case FindCommand.COMMAND_WORD:
         case FindCommand.COMMAND_ALIAS:
@@ -177,8 +179,27 @@ public class AutoComplete {
     /**
      * Auto-completes remark command.
      */
-    public static String remarkCommandAutoComplete(String args) {
-        return " ";
+    public static String remarkCommandAutoComplete(String args, Model model) {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_REMARK);
+
+        String indexString = argMultimap.getPreamble().trim();
+        Index index = null;
+        try {
+            index = ParserUtil.parseIndex(indexString);
+        } catch (IllegalValueException ive) {
+            indexString = formatSingleIndexString(indexString);
+        }
+
+        // if the index is invalid
+        if (index == null) {
+            return RemarkCommand.COMMAND_WORD + " " + indexString + " ";
+        }
+
+        // auto fill remark field
+        ReadOnlyPerson person = model.getFilteredPersonList().get(index.getZeroBased());
+        String prefixWithArgs = formatPrefixWithArgs(argMultimap, PREFIX_REMARK, person);
+
+        return RemarkCommand.COMMAND_WORD + " " + indexString +  " " + prefixWithArgs;
     }
 
     /**
@@ -263,6 +284,8 @@ public class AutoComplete {
         case PREFIX_TAG_STRING:
             return ParserUtil.parseTags(argList).stream().map(p -> (prefix + p.tagName))
                 .collect(Collectors.joining(" "));
+        case PREFIX_REMARK_STRING:
+            return prefix.getPrefix() + firstArg.get().trim();
         default:
             return prefix.getPrefix();
         }
@@ -284,6 +307,8 @@ public class AutoComplete {
             return person.getEmail().value;
         case PREFIX_ADDRESS_STRING:
             return person.getAddress().value;
+        case PREFIX_REMARK_STRING:
+            return person.getRemark().value;
         case PREFIX_TAG_STRING:
             return person.getTags().stream().map(Tag::toString).collect(Collectors.joining(" "));
         default:

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -190,17 +190,14 @@ public class AutoComplete {
     private static String remarkCommandAutoComplete(String args, List<ReadOnlyPerson> filteredPersonList) {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_REMARK);
 
-        String indexString = argMultimap.getPreamble().trim();
-        Index index = null;
+        String indexString = argMultimap.getPreamble();
+        Index index;
         try {
             index = ParserUtil.parseIndex(indexString);
         } catch (IllegalValueException ive) {
-            indexString = formatSingleIndexString(indexString);
-        }
-
-        // if the index is invalid
-        if (index == null) {
-            return RemarkCommand.COMMAND_WORD + " " + indexString + " ";
+            // if the index is invalid
+            String restArgs = args.replace(indexString, "").trim();
+            return RemarkCommand.COMMAND_WORD + " " + formatSingleIndexString(indexString) + " " + restArgs;
         }
 
         // auto fill remark field

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -123,17 +123,14 @@ public class AutoComplete {
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
-        String indexString = argMultimap.getPreamble().trim();
-        Index index = null;
+        String indexString = argMultimap.getPreamble();
+        Index index;
         try {
             index = ParserUtil.parseIndex(indexString);
         } catch (IllegalValueException ive) {
-            indexString = formatSingleIndexString(indexString);
-        }
-
-        // if the index is invalid
-        if (index == null) {
-            return EditCommand.COMMAND_WORD + " " + indexString + " ";
+            // if the index is invalid
+            String restArgs = args.substring(indexString.length() + 1).trim();
+            return EditCommand.COMMAND_WORD + " " + formatSingleIndexString(indexString) + " " + restArgs;
         }
 
         // auto fill all fields

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -14,6 +14,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK_STRING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_STRING;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -22,6 +26,7 @@ import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -322,4 +327,48 @@ public class AutoComplete {
         return arg.replaceAll("\\D", "");
     }
 
+    /**
+     *
+     */
+    private static List<String> getBestMatches(String[] tests, String tester) {
+        HashSet<String> bestMatchesSet = new HashSet<>();
+        int bestMatchScore = tester.length() + 1;
+        for (String test : tests) {
+            int lenDist = levenshteinDistance(tester, test);
+            if (lenDist == bestMatchScore) { // hit best match
+                bestMatchesSet.add(test);
+            } else if (lenDist < bestMatchScore) { // new best match
+                bestMatchesSet = new HashSet<>(Collections.singleton(test));
+            }
+        }
+        List<String> bestMatches = new ArrayList<>();
+        bestMatches.addAll(bestMatchesSet);
+        return bestMatches;
+    }
+
+    /**
+     * Calculate the levenshtein Distance of two {@code String}s.
+     */
+    private static int levenshteinDistance(String s, String t) {
+        if (s.length() == 0) {
+            return t.length();
+        }
+        if (t.length() == 0) {
+            return s.length();
+        }
+        if (s.charAt(0) == t.charAt(0)) {
+            return levenshteinDistance(s.substring(1), t.substring(1));
+        }
+        int substitute = levenshteinDistance(s.substring(1), t.substring(1));
+        int delete = levenshteinDistance(s, t.substring(1));
+        int insert = levenshteinDistance(s.substring(1), t);
+        return minimum(substitute, delete, insert) + 1;
+    }
+
+    /**
+     * @return minimum number of Integers.
+     */
+    private static int minimum(Integer... integers) {
+        return Arrays.stream(integers).reduce(Math::min).orElse(-1);
+    }
 }

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -12,22 +12,15 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ImportCommand;
-import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.RemarkCommand;
 import seedu.address.logic.commands.SearchCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.SortCommand;
-import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Prefix;
@@ -40,7 +33,7 @@ public class AutoComplete {
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
 
     /**
-     *
+     * Auto-completes the input String.
      */
     public static String autoComplete(String userInput) {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
@@ -72,17 +65,9 @@ public class AutoComplete {
         case RemarkCommand.COMMAND_ALIAS:
             return remarkCommandAutoComplete(arguments);
 
-        case ClearCommand.COMMAND_WORD:
-        case ClearCommand.COMMAND_ALIAS:
-            return "";
-
         case FindCommand.COMMAND_WORD:
         case FindCommand.COMMAND_ALIAS:
             return findCommandAutoComplete(arguments);
-
-        case ListCommand.COMMAND_WORD:
-        case ListCommand.COMMAND_ALIAS:
-            return "";
 
         case SortCommand.COMMAND_WORD:
             return sortCommandAutoComplete(arguments);
@@ -96,23 +81,6 @@ public class AutoComplete {
         case SearchCommand.COMMAND_WORD:
         case SearchCommand.COMMAND_ALIAS:
             return searchCommandAutoComplete(arguments);
-
-        case HistoryCommand.COMMAND_WORD:
-            return "";
-
-        case ExitCommand.COMMAND_WORD:
-            return "";
-
-        case HelpCommand.COMMAND_WORD:
-            return "";
-
-        case UndoCommand.COMMAND_WORD:
-        case UndoCommand.COMMAND_ALIAS:
-            return "";
-
-        case RedoCommand.COMMAND_WORD:
-        case RedoCommand.COMMAND_ALIAS:
-            return "";
 
         default:
             return unknownCommandAutoComplete(commandWord, arguments);
@@ -147,77 +115,77 @@ public class AutoComplete {
     }
 
     /**
-     * Formats the arguments into " PREFIX/ARGS" form.
+     * Auto-completes delete command.
      */
     public static String deleteCommandAutoComplete(String args) {
-        return " ";
+        return DeleteCommand.COMMAND_WORD +  " ";
     }
 
     /**
-     * Formats the arguments into " PREFIX/ARGS" form.
+     * Auto-completes edit command.
      */
     public static String editCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
-     * Formats the arguments into " PREFIX/ARGS" form.
+     * Auto-completes export command.
      */
     public static String exportCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
-     * Formats the arguments into " PREFIX/ARGS" form.
+     * Auto-completes find command.
      */
     public static String findCommandAutoComplete(String args) {
-        return " ";
+        return FindCommand.COMMAND_WORD + " ";
     }
 
     /**
-     * Formats the arguments into " PREFIX/ARGS" form.
+     * Auto-completes import command.
      */
     public static String importCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
-     * Formats the arguments into " PREFIX/ARGS" form.
+     * Auto-completes remark command.
      */
     public static String remarkCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
-     * Formats the arguments into " PREFIX/ARGS" form.
+     * Auto-completes search command.
      */
     public static String searchCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
-     * Formats the arguments into " PREFIX/ARGS" form.
+     * Auto-completes select command.
      */
     public static String selectCommandAutoComplete(String args) {
-        return " ";
+        return SelectCommand.COMMAND_WORD +  " ";
     }
 
     /**
-     * Formats the arguments into " PREFIX/ARGS" form.
+     * Auto-completes sort command.
      */
     public static String sortCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
-     * Formats the arguments into " PREFIX/ARGS" form.
+     * Auto-completes unknown command without arguments.
      */
     public static String unknownCommandAutoComplete(String args) {
         return " ";
     }
 
     /**
-     * Formats the arguments into " PREFIX/ARGS" form.
+     * Auto-completes unknown command.
      */
     public static String unknownCommandAutoComplete(String command, String args) {
         return " ";

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -1,0 +1,8 @@
+package seedu.address.logic;
+
+/**
+ * Utilities for auto completion for command.
+ */
+public class AutoComplete {
+
+}

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -151,6 +151,8 @@ public class AutoComplete {
         case PREFIX_TAG_STRING:
             arg = ParserUtil.parseTags(argList).stream().map(Optional::of).collect(Collectors.toList());
             break;
+        default:
+            assert false : "not possible";
         }
         return prefix + arg.stream().filter(Optional::isPresent).map(Optional::get).map(Object::toString)
             .collect(Collectors.joining(" " + prefix.getPrefix()));
@@ -186,13 +188,13 @@ public class AutoComplete {
 
         // auto fill all fields
         ReadOnlyPerson person = model.getFilteredPersonList().get(index.getZeroBased());
-        String prefixWithArgs = formatPrefixWithArgs(argMultimap, PREFIX_NAME, person)
-            + formatPrefixWithArgs(argMultimap, PREFIX_PHONE, person)
-            + formatPrefixWithArgs(argMultimap, PREFIX_EMAIL, person)
-            + formatPrefixWithArgs(argMultimap, PREFIX_ADDRESS, person)
+        String prefixWithArgs = formatPrefixWithArgs(argMultimap, PREFIX_NAME, person) + " "
+            + formatPrefixWithArgs(argMultimap, PREFIX_PHONE, person) + " "
+            + formatPrefixWithArgs(argMultimap, PREFIX_EMAIL, person) + " "
+            + formatPrefixWithArgs(argMultimap, PREFIX_ADDRESS, person) + " "
             + formatPrefixWithArgs(argMultimap, PREFIX_TAG, person);
 
-        return EditCommand.COMMAND_WORD + " " + indexString + prefixWithArgs;
+        return EditCommand.COMMAND_WORD + " " + indexString +  " " + prefixWithArgs;
     }
 
     /**
@@ -201,7 +203,7 @@ public class AutoComplete {
      */
     private static String formatPrefixWithArgs(ArgumentMultimap argMultimap, Prefix prefix, ReadOnlyPerson person) {
         String prefixWithArgs = formatPrefixWithArgs(argMultimap, prefix);
-        if (prefixWithArgs.equals(" " + prefix)) { // no input, read field info from person
+        if (prefixWithArgs.equals(prefix.getPrefix())) { // no input, read field info from person
             prefixWithArgs += getPersonFieldOfPrefix(person, prefix);
         }
         if (prefix.equals(PREFIX_TAG)) {

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -328,6 +328,19 @@ public class AutoComplete {
     }
 
     /**
+     * Finds all test in array that have prefix of tester and returns the result as a List.
+     */
+    private static List<String> prefixMatch(String[] tests, String tester) {
+        HashSet<String> prefixMatchesSet = new HashSet<>();
+        Pattern prefixPattern = Pattern.compile("^" + tester + "*$");
+        prefixMatchesSet.addAll(Arrays.stream(tests).filter(p -> prefixPattern.matcher(p).matches())
+            .collect(Collectors.toList()));
+        List<String> prefixMatches = new ArrayList<>();
+        prefixMatches.addAll(prefixMatchesSet);
+        return prefixMatches;
+    }
+
+    /**
      *
      */
     private static List<String> getBestMatches(String[] tests, String tester) {

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -17,7 +17,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_STRING;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -359,19 +358,12 @@ public class AutoComplete {
     }
 
     /**
-     *
+     * Finds the fuzzy match of tester in the Array.
      */
     private static List<String> fuzzyMatches(String[] tests, String tester) {
         HashSet<String> bestMatchesSet = new HashSet<>();
-        int bestMatchScore = tester.length() + 1;
-        for (String test : tests) {
-            int lenDist = levenshteinDistance(tester, test);
-            if (lenDist == bestMatchScore) { // hit best match
-                bestMatchesSet.add(test);
-            } else if (lenDist < bestMatchScore) { // new best match
-                bestMatchesSet = new HashSet<>(Collections.singleton(test));
-            }
-        }
+        bestMatchesSet.addAll(Arrays.stream(tests).filter(p -> levenshteinDistance(tester, p) > (p.length() / 2))
+            .collect(Collectors.toList()));
         List<String> bestMatches = new ArrayList<>();
         bestMatches.addAll(bestMatchesSet);
         return bestMatches;

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -5,4 +5,48 @@ package seedu.address.logic;
  */
 public class AutoComplete {
 
+    public void autoComplete(String command) {
+        String[] args = command.split("\\s+");
+    }
+
+    public void addCommandAutoComplete(String args) {
+
+    }
+
+    public String deleteCommandAutoComplete(String args) {
+        return " ";
+    }
+
+    public String editCommandAutoComplete(String args) {
+
+    }
+
+    public String exportCommandAutoComplete(String args) {
+
+    }
+
+    public String findCommandAutoComplete(String args) {
+
+    }
+
+    public String importCommandAutoComplete(String args) {
+
+    }
+
+    public String remarkCommandAutoComplete(String args) {
+
+    }
+
+    public String searchCommandAutoComplete(String args) {
+
+    }
+
+    public String selectCommandAutoComplete(String args) {
+
+    }
+
+    public String sortCommandAutoComplete(String args) {
+
+    }
+
 }

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -1,52 +1,226 @@
 package seedu.address.logic;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.ExportCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.HistoryCommand;
+import seedu.address.logic.commands.ImportCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.RedoCommand;
+import seedu.address.logic.commands.RemarkCommand;
+import seedu.address.logic.commands.SearchCommand;
+import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Prefix;
+
 /**
  * Utilities for auto completion for command.
  */
 public class AutoComplete {
 
-    public void autoComplete(String command) {
-        String[] args = command.split("\\s+");
+    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+
+    /**
+     *
+     */
+    public String autoComplete(String userInput) {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            return unknownCommandAutoComplete(userInput);
+        }
+
+        final String commandWord = matcher.group("commandWord");
+        final String arguments = matcher.group("arguments");
+        switch (commandWord) {
+
+        case AddCommand.COMMAND_WORD:
+        case AddCommand.COMMAND_ALIAS:
+            return addCommandAutoComplete(arguments);
+
+        case EditCommand.COMMAND_WORD:
+        case EditCommand.COMMAND_ALIAS:
+            return editCommandAutoComplete(arguments);
+
+        case SelectCommand.COMMAND_WORD:
+        case SelectCommand.COMMAND_ALIAS:
+            return selectCommandAutoComplete(arguments);
+
+        case DeleteCommand.COMMAND_WORD:
+        case DeleteCommand.COMMAND_ALIAS:
+            return deleteCommandAutoComplete(arguments);
+
+        case RemarkCommand.COMMAND_WORD:
+        case RemarkCommand.COMMAND_ALIAS:
+            return remarkCommandAutoComplete(arguments);
+
+        case ClearCommand.COMMAND_WORD:
+        case ClearCommand.COMMAND_ALIAS:
+            return "";
+
+        case FindCommand.COMMAND_WORD:
+        case FindCommand.COMMAND_ALIAS:
+            return findCommandAutoComplete(arguments);
+
+        case ListCommand.COMMAND_WORD:
+        case ListCommand.COMMAND_ALIAS:
+            return "";
+
+        case SortCommand.COMMAND_WORD:
+            return sortCommandAutoComplete(arguments);
+
+        case ExportCommand.COMMAND_WORD:
+            return exportCommandAutoComplete(arguments);
+
+        case ImportCommand.COMMAND_WORD:
+            return importCommandAutoComplete(arguments);
+
+        case SearchCommand.COMMAND_WORD:
+        case SearchCommand.COMMAND_ALIAS:
+            return searchCommandAutoComplete(arguments);
+
+        case HistoryCommand.COMMAND_WORD:
+            return "";
+
+        case ExitCommand.COMMAND_WORD:
+            return "";
+
+        case HelpCommand.COMMAND_WORD:
+            return "";
+
+        case UndoCommand.COMMAND_WORD:
+        case UndoCommand.COMMAND_ALIAS:
+            return "";
+
+        case RedoCommand.COMMAND_WORD:
+        case RedoCommand.COMMAND_ALIAS:
+            return "";
+
+        default:
+            return unknownCommandAutoComplete(commandWord, arguments);
+
+        }
     }
 
-    public void addCommandAutoComplete(String args) {
-
+    /**
+     * Auto-completes the prefix field that is not entered.
+     */
+    public String addCommandAutoComplete(String args) {
+        ArgumentMultimap argMultimap =
+            ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+        return AddCommand.COMMAND_WORD
+            + formatPrefixWithArgs(argMultimap, PREFIX_NAME)
+            + formatPrefixWithArgs(argMultimap, PREFIX_PHONE)
+            + formatPrefixWithArgs(argMultimap, PREFIX_EMAIL)
+            + formatPrefixWithArgs(argMultimap, PREFIX_ADDRESS)
+            + formatPrefixWithArgs(argMultimap, PREFIX_TAG);
     }
 
+    /**
+     * Formats the arguments into " PREFIX/ARGS" form.
+     */
+    private String formatPrefixWithArgs(ArgumentMultimap argMultimap, final Prefix prefix) {
+        String arg = "";
+        List<String> argList = argMultimap.getAllValues(prefix);
+        if (!argList.isEmpty()) {
+            arg = argList.stream().collect(Collectors.joining(" " + prefix.getPrefix()));
+        }
+        return " " + prefix + arg;
+    }
+
+    /**
+     * Formats the arguments into " PREFIX/ARGS" form.
+     */
     public String deleteCommandAutoComplete(String args) {
         return " ";
     }
 
+    /**
+     * Formats the arguments into " PREFIX/ARGS" form.
+     */
     public String editCommandAutoComplete(String args) {
-
+        return " ";
     }
 
+    /**
+     * Formats the arguments into " PREFIX/ARGS" form.
+     */
     public String exportCommandAutoComplete(String args) {
-
+        return " ";
     }
 
+    /**
+     * Formats the arguments into " PREFIX/ARGS" form.
+     */
     public String findCommandAutoComplete(String args) {
-
+        return " ";
     }
 
+    /**
+     * Formats the arguments into " PREFIX/ARGS" form.
+     */
     public String importCommandAutoComplete(String args) {
-
+        return " ";
     }
 
+    /**
+     * Formats the arguments into " PREFIX/ARGS" form.
+     */
     public String remarkCommandAutoComplete(String args) {
-
+        return " ";
     }
 
+    /**
+     * Formats the arguments into " PREFIX/ARGS" form.
+     */
     public String searchCommandAutoComplete(String args) {
-
+        return " ";
     }
 
+    /**
+     * Formats the arguments into " PREFIX/ARGS" form.
+     */
     public String selectCommandAutoComplete(String args) {
-
+        return " ";
     }
 
+    /**
+     * Formats the arguments into " PREFIX/ARGS" form.
+     */
     public String sortCommandAutoComplete(String args) {
+        return " ";
+    }
 
+    /**
+     * Formats the arguments into " PREFIX/ARGS" form.
+     */
+    public String unknownCommandAutoComplete(String args) {
+        return " ";
+    }
+
+    /**
+     * Formats the arguments into " PREFIX/ARGS" form.
+     */
+    public String unknownCommandAutoComplete(String command, String args) {
+        return " ";
     }
 
 }

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -38,7 +38,6 @@ import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.Model;
 import seedu.address.model.person.ReadOnlyPerson;
-import seedu.address.model.tag.Tag;
 
 /**
  * Utilities for auto completion for command.
@@ -310,7 +309,7 @@ public class AutoComplete {
         case PREFIX_REMARK_STRING:
             return person.getRemark().value;
         case PREFIX_TAG_STRING:
-            return person.getTags().stream().map(Tag::toString).collect(Collectors.joining(" "));
+            return person.getTags().stream().map(t -> t.tagName).collect(Collectors.joining(" "));
         default:
             return "";
         }

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -12,7 +12,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE_STRING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG_STRING;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -118,12 +120,40 @@ public class AutoComplete {
      * Formats the arguments into " PREFIX/ARGS" form.
      */
     private static String formatPrefixWithArgs(ArgumentMultimap argMultimap, final Prefix prefix) {
-        String arg = "";
-        List<String> argList = argMultimap.getAllValues(prefix);
-        if (!argList.isEmpty()) {
-            arg = argList.stream().collect(Collectors.joining(" " + prefix.getPrefix()));
+        try {
+            return parseArgOfPrefix(argMultimap.getAllValues(prefix), prefix);
+        } catch (IllegalValueException ive) {
+            return prefix.getPrefix();
         }
-        return prefix + arg;
+    }
+
+    /**
+     * Tests whether the argument is valid for certain {@code Prefix}.
+     */
+    private static String parseArgOfPrefix(List<String> argList, Prefix prefix) throws IllegalValueException {
+        if (argList.isEmpty()) {
+            return prefix.getPrefix();
+        }
+        List<Optional> arg = new ArrayList<>();
+        switch (prefix.getPrefix()) {
+        case PREFIX_ADDRESS_STRING:
+            arg.add(ParserUtil.parseAddress(Optional.of(argList.get(0))));
+            break;
+        case PREFIX_EMAIL_STRING:
+            arg.add(ParserUtil.parseEmail(Optional.of(argList.get(0))));
+            break;
+        case PREFIX_NAME_STRING:
+            arg.add(ParserUtil.parseName(Optional.of(argList.get(0))));
+            break;
+        case PREFIX_PHONE_STRING:
+            arg.add(ParserUtil.parsePhone(Optional.of(argList.get(0))));
+            break;
+        case PREFIX_TAG_STRING:
+            arg = ParserUtil.parseTags(argList).stream().map(Optional::of).collect(Collectors.toList());
+            break;
+        }
+        return prefix + arg.stream().filter(Optional::isPresent).map(Optional::get).map(Object::toString)
+            .collect(Collectors.joining(" " + prefix.getPrefix()));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -129,7 +129,7 @@ public class AutoComplete {
             index = ParserUtil.parseIndex(indexString);
         } catch (IllegalValueException ive) {
             // if the index is invalid
-            String restArgs = args.replace(indexString, "").trim();
+            String restArgs = args.replaceFirst(indexString, "").trim();
             return EditCommand.COMMAND_WORD + " " + formatSingleIndexString(indexString) + " " + restArgs;
         }
 
@@ -143,7 +143,8 @@ public class AutoComplete {
                 + formatPrefixWithArgs(argMultimap, PREFIX_ADDRESS, person) + " "
                 + formatPrefixWithArgs(argMultimap, PREFIX_TAG, person);
         } catch (IndexOutOfBoundsException e) {
-            prefixWithArgs = "";
+            String restArgs = args.replaceFirst(indexString, "").trim();
+            return EditCommand.COMMAND_WORD + " " + formatSingleIndexString(indexString) + " " + restArgs;
         }
 
         return EditCommand.COMMAND_WORD + " " + indexString +  " " + prefixWithArgs;
@@ -196,7 +197,7 @@ public class AutoComplete {
             index = ParserUtil.parseIndex(indexString);
         } catch (IllegalValueException ive) {
             // if the index is invalid
-            String restArgs = args.replace(indexString, "").trim();
+            String restArgs = args.replaceFirst(indexString, "").trim();
             return RemarkCommand.COMMAND_WORD + " " + formatSingleIndexString(indexString) + " " + restArgs;
         }
 

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -254,7 +254,7 @@ public class AutoComplete {
             prefixMatch.sort(String::compareTo);
             return promptForPossibleCommand(prefixMatch);
         } else { // no prefix-match
-            List<String> fuzzyMatch = fuzzyMatches(getSystemCommandWords(), command);
+            List<String> fuzzyMatch = fuzzyMatch(getSystemCommandWords(), command);
             if (fuzzyMatch.isEmpty()) {
                 return command + args;
             }
@@ -374,7 +374,7 @@ public class AutoComplete {
     /**
      * Finds the fuzzy match of tester in the Array.
      */
-    private static List<String> fuzzyMatches(String[] tests, String tester) {
+    private static List<String> fuzzyMatch(String[] tests, String tester) {
         HashSet<String> bestMatchesSet = new HashSet<>();
         bestMatchesSet.addAll(Arrays.stream(tests)
             .filter(p -> levenshteinDistance(tester, p) <= (p.length() / 2)) // fuzzy match cut-off

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -129,7 +129,7 @@ public class AutoComplete {
             index = ParserUtil.parseIndex(indexString);
         } catch (IllegalValueException ive) {
             // if the index is invalid
-            String restArgs = args.substring(indexString.length() + 1).trim();
+            String restArgs = args.replace(indexString, "").trim();
             return EditCommand.COMMAND_WORD + " " + formatSingleIndexString(indexString) + " " + restArgs;
         }
 

--- a/src/main/java/seedu/address/logic/AutoComplete.java
+++ b/src/main/java/seedu/address/logic/AutoComplete.java
@@ -30,10 +30,8 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExportCommand;
-import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.RemarkCommand;
-import seedu.address.logic.commands.SearchCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
@@ -83,10 +81,6 @@ public class AutoComplete {
         case RemarkCommand.COMMAND_ALIAS:
             return remarkCommandAutoComplete(arguments, model);
 
-        case FindCommand.COMMAND_WORD:
-        case FindCommand.COMMAND_ALIAS:
-            return findCommandAutoComplete(arguments);
-
         case SortCommand.COMMAND_WORD:
             return sortCommandAutoComplete(arguments);
 
@@ -95,10 +89,6 @@ public class AutoComplete {
 
         case ImportCommand.COMMAND_WORD:
             return importCommandAutoComplete(arguments);
-
-        case SearchCommand.COMMAND_WORD:
-        case SearchCommand.COMMAND_ALIAS:
-            return searchCommandAutoComplete(arguments);
 
         default:
             return unknownCommandAutoComplete(commandWord, arguments);
@@ -166,13 +156,6 @@ public class AutoComplete {
     }
 
     /**
-     * Auto-completes find command.
-     */
-    public static String findCommandAutoComplete(String args) {
-        return FindCommand.COMMAND_WORD + " ";
-    }
-
-    /**
      * Auto-completes import command.
      */
     public static String importCommandAutoComplete(String args) {
@@ -203,13 +186,6 @@ public class AutoComplete {
         String prefixWithArgs = formatPrefixWithArgs(argMultimap, PREFIX_REMARK, person);
 
         return RemarkCommand.COMMAND_WORD + " " + indexString +  " " + prefixWithArgs;
-    }
-
-    /**
-     * Auto-completes search command.
-     */
-    public static String searchCommandAutoComplete(String args) {
-        return SearchCommand.COMMAND_WORD + " ";
     }
 
     /**

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -11,6 +11,11 @@ import seedu.address.model.person.ReadOnlyPerson;
  */
 public interface Logic {
     /**
+     * Tries to auto-complete the error command and returns it.
+     */
+    String autoCompleteCommand(String command);
+
+    /**
      * Executes the command and returns the result.
      * @param commandText The command as entered by the user.
      * @return the result of the command execution.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -32,6 +32,11 @@ public class LogicManager extends ComponentManager implements Logic {
     }
 
     @Override
+    public String autoCompleteCommand(String command) {
+        return AutoComplete.autoComplete(command, model.getFilteredPersonList());
+    }
+
+    @Override
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
         try {

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -5,12 +5,20 @@ package seedu.address.logic.parser;
  */
 public class CliSyntax {
 
+    /* Prefix name strings */
+    public static final String PREFIX_NAME_STRING = "n/";
+    public static final String PREFIX_PHONE_STRING = "p/";
+    public static final String PREFIX_EMAIL_STRING = "e/";
+    public static final String PREFIX_ADDRESS_STRING = "a/";
+    public static final String PREFIX_TAG_STRING = "t/";
+    public static final String PREFIX_REMARK_STRING = "r/";
+
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("n/");
-    public static final Prefix PREFIX_PHONE = new Prefix("p/");
-    public static final Prefix PREFIX_EMAIL = new Prefix("e/");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
-    public static final Prefix PREFIX_TAG = new Prefix("t/");
-    public static final Prefix PREFIX_REMARK = new Prefix("r/");
+    public static final Prefix PREFIX_NAME = new Prefix(PREFIX_NAME_STRING);
+    public static final Prefix PREFIX_PHONE = new Prefix(PREFIX_PHONE_STRING);
+    public static final Prefix PREFIX_EMAIL = new Prefix(PREFIX_EMAIL_STRING);
+    public static final Prefix PREFIX_ADDRESS = new Prefix(PREFIX_ADDRESS_STRING);
+    public static final Prefix PREFIX_TAG = new Prefix(PREFIX_TAG_STRING);
+    public static final Prefix PREFIX_REMARK = new Prefix(PREFIX_REMARK_STRING);
 
 }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,5 +1,7 @@
 package seedu.address.ui;
 
+import static seedu.address.logic.AutoComplete.autoComplete;
+
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -112,8 +114,9 @@ public class CommandBox extends UiPart<Region> {
         } catch (CommandException | ParseException e) {
             initHistory();
             // handle command failure
-            setStyleToIndicateCommandFailure();
             logger.info("Invalid command: " + commandTextField.getText());
+            commandTextField.setText(autoComplete(commandTextField.getText(), logic.getFilteredPersonList()));
+            setStyleToIndicateCommandFailure();
             raise(new NewResultAvailableEvent(e.getMessage()));
         }
     }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,7 +1,5 @@
 package seedu.address.ui;
 
-import static seedu.address.logic.AutoComplete.autoComplete;
-
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -115,7 +113,7 @@ public class CommandBox extends UiPart<Region> {
             initHistory();
             // handle command failure
             logger.info("Invalid command: " + commandTextField.getText());
-            commandTextField.setText(autoComplete(commandTextField.getText(), logic.getFilteredPersonList()));
+            commandTextField.setText(logic.autoCompleteCommand(commandTextField.getText()));
             setStyleToIndicateCommandFailure();
             raise(new NewResultAvailableEvent(e.getMessage()));
         }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -114,6 +114,7 @@ public class CommandBox extends UiPart<Region> {
             // handle command failure
             logger.info("Invalid command: " + commandTextField.getText());
             commandTextField.setText(logic.autoCompleteCommand(commandTextField.getText()));
+            commandTextField.end();
             setStyleToIndicateCommandFailure();
             raise(new NewResultAvailableEvent(e.getMessage()));
         }

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -36,10 +36,10 @@ import seedu.address.model.person.Remark;
 
 public class AutoCompleteTest {
 
+    private static final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
-
-    private static final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void autoCompleteAdd_missingOneField_addMissingPrefix() {
@@ -83,7 +83,7 @@ public class AutoCompleteTest {
         // two name field -> choose the first one
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + NAME_DESC_BOB + PHONE_DESC_AMY
             + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND;
-        expected= AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
+        expected = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
             + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND;
         assertAutoComplete(command, expected);
     }

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -1,0 +1,15 @@
+package seedu.address.logic;
+
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class AutoCompleteTest {
+
+    private static final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+}

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -311,7 +311,7 @@ public class AutoCompleteTest {
 
         // no hit
         command = "zzzzz";
-        assertAutoComplete(command, "");
+        assertAutoComplete(command, command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -18,6 +18,7 @@ import static seedu.address.testutil.PersonUtil.getPersonDetails;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -169,6 +170,9 @@ public class AutoCompleteTest {
         expected = EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased()
             + " " + getPersonDetails(expectedPerson).trim();
         assertAutoComplete(command, expected);
+
+        // index out of boundary -> leave the args
+        assertEquals(command, AutoComplete.autoComplete(command, new ArrayList<>()));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -169,6 +169,23 @@ public class AutoCompleteTest {
     }
 
     @Test
+    public void autoCompleteExport_invalidIndexes_trimNonDigitChars() {
+        String command = "export 1a 2a,, 3*.;   SomeFile.xml ";
+        String expected = "export 1, 2, 3; SomeFile.xml";
+        assertAutoComplete(command, expected);
+    }
+
+    @Test
+    public void autoCompleteExport_noDelimiter_trimNonDigitChars() {
+        String command = "export 1, 2, 3 SomeFile.xml ";
+        String expected = "export 1, 2, 3; SomeFile.xml";
+        assertAutoComplete(command, expected);
+
+        command = "export 1, 2, 3,SomeFile.xml ";
+        assertAutoComplete(command, expected);
+    }
+
+    @Test
     public void autoCompleteImport_anyArgument_trimWhitespaces() {
         String command = "import  someFile.xml  ";
         String expected = "import someFile.xml";

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -32,6 +32,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.ReadOnlyPerson;
+import seedu.address.model.person.Remark;
 
 public class AutoCompleteTest {
 
@@ -189,6 +190,25 @@ public class AutoCompleteTest {
 
         command = "import     ";
         expected = "import ";
+        assertAutoComplete(command, expected);
+    }
+
+    @Test
+    public void autoCompleteRemark_invalidIndex_trimWhitespaces() {
+        String command = "remark aa1,1a";
+        String expected = "remark 11 ";
+        assertAutoComplete(command, expected);
+
+        command = "remark   a1, 1  a";
+        assertAutoComplete(command, expected);
+    }
+
+    @Test
+    public void autoCompleteRemark_firstIndexEmptyField_autoFillRemarkField() {
+        String validRemark = "valid remark";
+        String command = "remark 1 r/";
+        model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()).setRemark(new Remark(validRemark));
+        String expected = command + validRemark;
         assertAutoComplete(command, expected);
     }
 

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -84,6 +84,25 @@ public class AutoCompleteTest {
         assertAutoComplete(command, command);
     }
 
+    @Test
+    public void autoCompleteDelete_invalidIndex_trimNonDigitChar() {
+        String command = "delete 1a";
+        String expected = "delete 1";
+        assertAutoComplete(command, expected);
+
+        command = "delete aa1bb   ";
+        assertAutoComplete(command, expected);
+
+        command = "delete a  1  b";
+        assertAutoComplete(command, expected);
+    }
+
+    @Test
+    public void autoCompleteDelete_validIndex_noChange() {
+        String command = "delete 1";
+        assertAutoComplete(command, command);
+    }
+
     /**
      * Asserts if the auto-complete of {@code command} equals to {@code expectedResult}.
      */

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -205,7 +205,8 @@ public class AutoCompleteTest {
         String expected = "remark 11 ";
         assertAutoComplete(command, expected);
 
-        command = "remark   a1, 1  a";
+        command = "   remark   a1, 1  a r/Some remark";
+        expected = "remark 11 r/Some remark";
         assertAutoComplete(command, expected);
     }
 

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -126,7 +126,7 @@ public class AutoCompleteTest {
         command = "edit a1,1a ";
         assertAutoComplete(command, expected);
 
-        command = "edit a1a1a n/Some Name";
+        command = "    edit   a1a 1   a    n/Some Name";
         expected = "edit 11 n/Some Name";
         assertAutoComplete(command, expected);
     }

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -127,7 +127,7 @@ public class AutoCompleteTest {
         assertAutoComplete(command, expected);
 
         command = "edit a1a1a n/Some Name";
-        //TODO: this command should be corrected to "edit 11 n/Some Name"
+        expected = "edit 11 n/Some Name";
         assertAutoComplete(command, expected);
     }
 

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -1,12 +1,24 @@
 package seedu.address.logic;
 
 import static org.junit.Assert.assertEquals;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -14,28 +26,62 @@ import seedu.address.model.UserPrefs;
 public class AutoCompleteTest {
 
     @Rule
-    private static final ExpectedException thrown = ExpectedException.none();
+    public ExpectedException thrown = ExpectedException.none();
 
     private static final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void autoCompleteAdd_missingOneField_addMissingPrefix() {
+        // missing phone
+        String command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND;
+        String expected = AddCommand.COMMAND_WORD + NAME_DESC_AMY
+            + " " + PREFIX_PHONE + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND;
+        assertAutoComplete(command, expected);
 
+        // missing address
+        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND;
+        expected = AddCommand.COMMAND_WORD + NAME_DESC_AMY
+            + PHONE_DESC_AMY + EMAIL_DESC_AMY + " " + PREFIX_ADDRESS + TAG_DESC_FRIEND;
+        assertAutoComplete(command, expected);
     }
 
     @Test
     public void autoCompleteAdd_missingMultipleFields_addMissingPrefixes() {
+        // missing name and email
+        String command = AddCommand.COMMAND_WORD + PHONE_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND;
+        String expected = AddCommand.COMMAND_WORD + " " + PREFIX_NAME + PHONE_DESC_AMY
+            + " " + PREFIX_EMAIL + ADDRESS_DESC_AMY + TAG_DESC_FRIEND;
+        assertAutoComplete(command, expected);
 
+        // all fields are missing
+        command = AddCommand.COMMAND_WORD;
+        expected = AddCommand.COMMAND_WORD + " " + PREFIX_NAME + " " + PREFIX_PHONE + " " + PREFIX_EMAIL
+            + " " + PREFIX_ADDRESS + " " + PREFIX_TAG;
+        assertAutoComplete(command, expected);
     }
 
     @Test
     public void autoCompleteAdd_invalidFields_addMissingPrefixes() {
+        // invalid phone
+        String command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + " " + PREFIX_PHONE + "abc"
+            + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND;
+        String expected = AddCommand.COMMAND_WORD + NAME_DESC_AMY
+            + " " + PREFIX_PHONE + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND;
+        assertAutoComplete(command, expected);
 
+        // two name field -> choose the first one
+        command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + NAME_DESC_BOB + PHONE_DESC_AMY
+            + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND;
+        expected= AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
+            + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND;
+        assertAutoComplete(command, expected);
     }
 
     @Test
     public void autoCompleteAdd_allValidFields_noChange() {
-
+        String command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
+            + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_FRIEND;
+        assertAutoComplete(command, command);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -168,20 +168,6 @@ public class AutoCompleteTest {
         assertAutoComplete(command, expected);
     }
 
-
-    @Test
-    public void autoCompleteFind_anyArgument_trimAllArgs() {
-        String command = "find some args";
-        String expected = "find ";
-        assertAutoComplete(command, expected);
-
-        command = "find";
-        assertAutoComplete(command, expected);
-
-        command = "find arg with whitespaces  ";
-        assertAutoComplete(command, expected);
-    }
-
     @Test
     public void autoCompleteImport_anyArgument_trimWhitespaces() {
         String command = "import  someFile.xml  ";

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -181,6 +181,17 @@ public class AutoCompleteTest {
         assertAutoComplete(command, expected);
     }
 
+    @Test
+    public void autoCompleteImport_anyArgument_trimWhitespaces() {
+        String command = "import  someFile.xml  ";
+        String expected = "import someFile.xml";
+        assertAutoComplete(command, expected);
+
+        command = "import     ";
+        expected = "import ";
+        assertAutoComplete(command, expected);
+    }
+
     /**
      * Asserts if the auto-complete of {@code command} equals to {@code expectedResult}.
      */

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -10,8 +10,13 @@ import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME_STRING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE_STRING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.testutil.PersonUtil.getPersonDetails;
+import static seedu.address.testutil.TestUtil.getPerson;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.Rule;
@@ -19,9 +24,14 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.EditCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.ReadOnlyPerson;
 
 public class AutoCompleteTest {
 
@@ -114,6 +124,60 @@ public class AutoCompleteTest {
 
         command = "edit a1a1a n/Some Name";
         //TODO: this command should be corrected to "edit 11 n/Some Name"
+        assertAutoComplete(command, expected);
+    }
+
+    @Test
+    public void autoCompleteEdit_firstIndexInvalidField_autoFillFields() {
+        ReadOnlyPerson firstPerson = getPerson(model, INDEX_FIRST_PERSON);
+        String expected = EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased()
+            + " " + getPersonDetails(firstPerson).trim();
+
+        // empty field
+        String command = "edit 1 n/";
+        assertAutoComplete(command, expected);
+
+        // invalid field
+        command = "edit  1  p/a";
+        assertAutoComplete(command, expected);
+
+        // multiple invalid fields
+        command = "edit  1 p/a e/aa";
+        assertAutoComplete(command, expected);
+    }
+
+    @Test
+    public void autoCompleteEdit_firstIndexValidFields_autoFillTheRestFields() throws Exception {
+        ReadOnlyPerson firstPerson = getPerson(model, INDEX_FIRST_PERSON);
+
+        String validName = "Valid Name";
+        String command = "edit 1 " + PREFIX_NAME_STRING + validName;
+        Person expectedPerson = new Person(firstPerson);
+        expectedPerson.setName(new Name(validName));
+        String expected = EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased()
+            + " " + getPersonDetails(expectedPerson).trim();
+        assertAutoComplete(command, expected);
+
+        String validPhone = "1234567";
+        command = "edit 1 " + PREFIX_PHONE_STRING + validPhone;
+        expectedPerson = new Person(firstPerson);
+        expectedPerson.setPhone(new Phone(validPhone));
+        expected = EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased()
+            + " " + getPersonDetails(expectedPerson).trim();
+        assertAutoComplete(command, expected);
+    }
+
+
+    @Test
+    public void autoCompleteFind_anyArgument_trimAllArgs() {
+        String command = "find some args";
+        String expected = "find ";
+        assertAutoComplete(command, expected);
+
+        command = "find";
+        assertAutoComplete(command, expected);
+
+        command = "find arg with whitespaces  ";
         assertAutoComplete(command, expected);
     }
 

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -1,8 +1,11 @@
 package seedu.address.logic;
 
+import static org.junit.Assert.assertEquals;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -10,6 +13,36 @@ import seedu.address.model.UserPrefs;
 
 public class AutoCompleteTest {
 
+    @Rule
+    private static final ExpectedException thrown = ExpectedException.none();
+
     private static final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
+    @Test
+    public void autoCompleteAdd_missingOneField_addMissingPrefix() {
+
+    }
+
+    @Test
+    public void autoCompleteAdd_missingMultipleFields_addMissingPrefixes() {
+
+    }
+
+    @Test
+    public void autoCompleteAdd_invalidFields_addMissingPrefixes() {
+
+    }
+
+    @Test
+    public void autoCompleteAdd_allValidFields_noChange() {
+
+    }
+
+    /**
+     * Asserts if the auto-complete of {@code command} equals to {@code expectedResult}.
+     */
+    private void assertAutoComplete(String command, String expectedResult) {
+        String result = AutoComplete.autoComplete(command, model);
+        assertEquals(result, expectedResult);
+    }
 }

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -244,6 +244,21 @@ public class AutoCompleteTest {
     }
 
     @Test
+    public void autoCompleteSort_containMultiplePrefix_onlyReturnName() {
+        String command = "sort n/p/  ";
+        String expected = "sort n/";
+        assertAutoComplete(command, expected);
+
+        command = "sort reverse p/ ";
+        expected = "sort p/ reverse";
+        assertAutoComplete(command, expected);
+
+        command = "sort n/ reverse p/ ";
+        expected = "sort n/ reverse";
+        assertAutoComplete(command, expected);
+    }
+
+    @Test
     public void autoCompleteUnknownCommand_prefixMatch_autoCompleteCommand() {
         String command = "ad   n/Some Name  ";
         String expected = "add n/Some Name";

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -19,12 +19,19 @@ import static seedu.address.testutil.TestUtil.getPerson;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.ExportCommand;
+import seedu.address.logic.commands.SearchCommand;
+import seedu.address.logic.commands.SelectCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -234,11 +241,62 @@ public class AutoCompleteTest {
         assertAutoComplete(command, command);
     }
 
+    @Test
+    public void autoCompleteUnknownCommand_prefixMatch_autoCompleteCommand() {
+        String command = "ad   n/Some Name  ";
+        String expected = "add n/Some Name";
+        assertAutoComplete(command, expected);
+
+        command = "cle  ";
+        expected = "clear ";
+        assertAutoComplete(command, expected);
+
+        command = "de  1  ";
+        expected = "delete 1";
+        assertAutoComplete(command, expected);
+
+        command = "ed 1 n/Some Name  ";
+        expected = "edit 1 n/Some Name";
+        assertAutoComplete(command, expected);
+
+        command = "exi  ";
+        expected = "exit ";
+        assertAutoComplete(command, expected);
+
+        command = "exp   1, 2; m.xml   ";
+        expected = "export 1, 2; m.xml";
+        assertAutoComplete(command, expected);
+
+        command = "fi x ";
+        expected = "find x";
+        assertAutoComplete(command, expected);
+    }
+
+    @Test
+    public void autoCompleteUnknownCommand_multiplePrefixMatches_autoCompleteCommand() {
+        // exit and export
+        String command = "ex";
+        String expected = getUnknownCommandPrompt(ExitCommand.COMMAND_WORD, ExportCommand.COMMAND_WORD);
+        assertAutoComplete(command, expected);
+
+        // search and select
+        command = "se";
+        expected = getUnknownCommandPrompt(SearchCommand.COMMAND_WORD, SelectCommand.COMMAND_WORD);
+        assertAutoComplete(command, expected);
+    }
+
     /**
      * Asserts if the auto-complete of {@code command} equals to {@code expectedResult}.
      */
     private void assertAutoComplete(String command, String expectedResult) {
         String result = AutoComplete.autoComplete(command, model);
         assertEquals(result, expectedResult);
+    }
+
+    /**
+     * Returns the prompt String for suggestions.
+     */
+    private String getUnknownCommandPrompt(String... suggestions) {
+        return "Do you mean: " + Arrays.stream(suggestions).collect(Collectors.joining(" or ")) + " ?";
     }
 }

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -15,9 +15,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE_STRING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.PersonUtil.getPersonDetails;
-import static seedu.address.testutil.TestUtil.getPerson;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -34,9 +33,6 @@ import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.SearchCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.SortCommand;
-import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -44,8 +40,6 @@ import seedu.address.model.person.ReadOnlyPerson;
 import seedu.address.model.person.Remark;
 
 public class AutoCompleteTest {
-
-    private static final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -139,7 +133,7 @@ public class AutoCompleteTest {
 
     @Test
     public void autoCompleteEdit_firstIndexInvalidField_autoFillFields() {
-        ReadOnlyPerson firstPerson = getPerson(model, INDEX_FIRST_PERSON);
+        ReadOnlyPerson firstPerson = getTypicalPersons().get(INDEX_FIRST_PERSON.getZeroBased());
         String expected = EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased()
             + " " + getPersonDetails(firstPerson).trim();
 
@@ -158,7 +152,7 @@ public class AutoCompleteTest {
 
     @Test
     public void autoCompleteEdit_firstIndexValidFields_autoFillTheRestFields() throws Exception {
-        ReadOnlyPerson firstPerson = getPerson(model, INDEX_FIRST_PERSON);
+        ReadOnlyPerson firstPerson = getTypicalPersons().get(INDEX_FIRST_PERSON.getZeroBased());
 
         String validName = "Valid Name";
         String command = "edit 1 " + PREFIX_NAME_STRING + validName;
@@ -219,7 +213,7 @@ public class AutoCompleteTest {
     public void autoCompleteRemark_firstIndexEmptyField_autoFillRemarkField() {
         String validRemark = "valid remark";
         String command = "remark 1 r/";
-        model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()).setRemark(new Remark(validRemark));
+        getTypicalPersons().get(INDEX_FIRST_PERSON.getZeroBased()).setRemark(new Remark(validRemark));
         String expected = command + validRemark;
         assertAutoComplete(command, expected);
     }
@@ -330,7 +324,7 @@ public class AutoCompleteTest {
      * Asserts if the auto-complete of {@code command} equals to {@code expectedResult}.
      */
     private void assertAutoComplete(String command, String expectedResult) {
-        String result = AutoComplete.autoComplete(command, model);
+        String result = AutoComplete.autoComplete(command, getTypicalPersons());
         assertEquals(result, expectedResult);
     }
 

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -30,8 +30,10 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.ExportCommand;
+import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.SearchCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.SortCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -283,6 +285,24 @@ public class AutoCompleteTest {
         command = "se";
         expected = getUnknownCommandPrompt(SearchCommand.COMMAND_WORD, SelectCommand.COMMAND_WORD);
         assertAutoComplete(command, expected);
+    }
+
+    @Test
+    public void autoCompleteUnknownCommand_fuzzyMatches_autoCompleteCommand() {
+        // single hit
+        String command = "adda ";
+        String expected = getUnknownCommandPrompt(AddCommand.COMMAND_WORD);
+        assertAutoComplete(command, expected);
+
+        // multiple hits
+        command = "port";
+        expected = getUnknownCommandPrompt(ExportCommand.COMMAND_WORD, ImportCommand.COMMAND_WORD,
+                                           SortCommand.COMMAND_WORD);
+        assertAutoComplete(command, expected);
+
+        // no hit
+        command = "zzzzz";
+        assertAutoComplete(command, "");
     }
 
     /**

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -103,6 +103,20 @@ public class AutoCompleteTest {
         assertAutoComplete(command, command);
     }
 
+    @Test
+    public void autoCompleteEdit_invalidIndex_trimNonDigitChar() {
+        String command = "edit 11a";
+        String expected = "edit 11 ";
+        assertAutoComplete(command, expected);
+
+        command = "edit a1,1a ";
+        assertAutoComplete(command, expected);
+
+        command = "edit a1a1a n/Some Name";
+        //TODO: this command should be corrected to "edit 11 n/Some Name"
+        assertAutoComplete(command, expected);
+    }
+
     /**
      * Asserts if the auto-complete of {@code command} equals to {@code expectedResult}.
      */

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -305,6 +305,12 @@ public class AutoCompleteTest {
         assertAutoComplete(command, "");
     }
 
+    @Test
+    public void autoCompleteUnknownCommand_emptyInput_emptyReturn() {
+        String command = "     ";
+        assertAutoComplete(command, "");
+    }
+
     /**
      * Asserts if the auto-complete of {@code command} equals to {@code expectedResult}.
      */

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -200,7 +200,7 @@ public class AutoCompleteTest {
     }
 
     @Test
-    public void autoCompleteRemark_invalidIndex_trimWhitespaces() {
+    public void autoCompleteRemark_invalidIndex_trimNonDigitChars() {
         String command = "remark aa1,1a";
         String expected = "remark 11 ";
         assertAutoComplete(command, expected);

--- a/src/test/java/seedu/address/logic/AutoCompleteTest.java
+++ b/src/test/java/seedu/address/logic/AutoCompleteTest.java
@@ -212,6 +212,25 @@ public class AutoCompleteTest {
         assertAutoComplete(command, expected);
     }
 
+    @Test
+    public void autoCompleteSelect_invalidIndex_trimNonDigitChar() {
+        String command = "select 1a";
+        String expected = "select 1";
+        assertAutoComplete(command, expected);
+
+        command = "select aa1bb   ";
+        assertAutoComplete(command, expected);
+
+        command = "select a  1  b";
+        assertAutoComplete(command, expected);
+    }
+
+    @Test
+    public void autoCompleteSelect_validIndex_noChange() {
+        String command = "select 1";
+        assertAutoComplete(command, command);
+    }
+
     /**
      * Asserts if the auto-complete of {@code command} equals to {@code expectedResult}.
      */

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -1,6 +1,7 @@
 package systemtests;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.AutoComplete.autoComplete;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -244,7 +245,8 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
         Model expectedModel = getModel();
 
         executeCommand(command);
-        assertApplicationDisplaysExpected(command, expectedResultMessage, expectedModel);
+        assertApplicationDisplaysExpected(
+            autoComplete(command, expectedModel.getFilteredPersonList()), expectedResultMessage, expectedModel);
         assertSelectedCardUnchanged();
         assertCommandBoxShowsErrorStyle();
         assertStatusBarUnchanged();

--- a/src/test/java/systemtests/ClearCommandSystemTest.java
+++ b/src/test/java/systemtests/ClearCommandSystemTest.java
@@ -1,6 +1,7 @@
 package systemtests;
 
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.AutoComplete.autoComplete;
 import static seedu.address.testutil.TypicalPersons.KEYWORD_MATCHING_MEIER;
 
 import org.junit.Test;
@@ -93,7 +94,8 @@ public class ClearCommandSystemTest extends AddressBookSystemTest {
         Model expectedModel = getModel();
 
         executeCommand(command);
-        assertApplicationDisplaysExpected(command, expectedResultMessage, expectedModel);
+        assertApplicationDisplaysExpected(
+            autoComplete(command, expectedModel.getFilteredPersonList()), expectedResultMessage, expectedModel);
         assertSelectedCardUnchanged();
         assertCommandBoxShowsErrorStyle();
         assertStatusBarUnchanged();

--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -3,6 +3,7 @@ package systemtests;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.AutoComplete.autoComplete;
 import static seedu.address.logic.commands.DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS;
 import static seedu.address.testutil.TestUtil.getLastIndex;
 import static seedu.address.testutil.TestUtil.getMidIndex;
@@ -192,7 +193,8 @@ public class DeleteCommandSystemTest extends AddressBookSystemTest {
         Model expectedModel = getModel();
 
         executeCommand(command);
-        assertApplicationDisplaysExpected(command, expectedResultMessage, expectedModel);
+        assertApplicationDisplaysExpected(
+            autoComplete(command, expectedModel.getFilteredPersonList()), expectedResultMessage, expectedModel);
         assertSelectedCardUnchanged();
         assertCommandBoxShowsErrorStyle();
         assertStatusBarUnchanged();

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -2,6 +2,7 @@ package systemtests;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.AutoComplete.autoComplete;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -275,7 +276,8 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         Model expectedModel = getModel();
 
         executeCommand(command);
-        assertApplicationDisplaysExpected(command, expectedResultMessage, expectedModel);
+        assertApplicationDisplaysExpected(
+            autoComplete(command, expectedModel.getFilteredPersonList()), expectedResultMessage, expectedModel);
         assertSelectedCardUnchanged();
         assertCommandBoxShowsErrorStyle();
         assertStatusBarUnchanged();

--- a/src/test/java/systemtests/ExportCommandSystemTest.java
+++ b/src/test/java/systemtests/ExportCommandSystemTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.AutoComplete.autoComplete;
 import static seedu.address.testutil.TestUtil.getLastIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.KEYWORD_MATCHING_MEIER;
@@ -222,7 +223,8 @@ public class ExportCommandSystemTest extends AddressBookSystemTest {
         Model expectedModel = getModel();
 
         executeCommand(command);
-        assertApplicationDisplaysExpected(command, expectedMessage, expectedModel);
+        assertApplicationDisplaysExpected(
+            autoComplete(command, expectedModel.getFilteredPersonList()), expectedMessage, expectedModel);
         assertCommandBoxShowsErrorStyle();
         assertSelectedCardUnchanged();
         assertStatusBarUnchanged();

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -2,6 +2,7 @@ package systemtests;
 
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.AutoComplete.autoComplete;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
@@ -188,7 +189,8 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         Model expectedModel = getModel();
 
         executeCommand(command);
-        assertApplicationDisplaysExpected(command, expectedResultMessage, expectedModel);
+        assertApplicationDisplaysExpected(
+            autoComplete(command, expectedModel.getFilteredPersonList()), expectedResultMessage, expectedModel);
         assertSelectedCardUnchanged();
         assertCommandBoxShowsErrorStyle();
         assertStatusBarUnchanged();

--- a/src/test/java/systemtests/ImportCommandSystemTest.java
+++ b/src/test/java/systemtests/ImportCommandSystemTest.java
@@ -2,6 +2,7 @@ package systemtests;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.AutoComplete.autoComplete;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BOB;
@@ -146,7 +147,8 @@ public class ImportCommandSystemTest extends AddressBookSystemTest {
     private void assertCommandFailure(String command, String expectedResultMessage) {
         Model expectedModel = getModel();
         executeCommand(command);
-        assertApplicationDisplaysExpected(command, expectedResultMessage, expectedModel);
+        assertApplicationDisplaysExpected(
+            autoComplete(command, expectedModel.getFilteredPersonList()), expectedResultMessage, expectedModel);
         assertCommandBoxShowsErrorStyle();
         assertStatusBarUnchanged();
     }

--- a/src/test/java/systemtests/SelectCommandSystemTest.java
+++ b/src/test/java/systemtests/SelectCommandSystemTest.java
@@ -3,6 +3,7 @@ package systemtests;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.AutoComplete.autoComplete;
 import static seedu.address.logic.commands.SelectCommand.MESSAGE_SELECT_PERSON_SUCCESS;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.KEYWORD_MATCHING_MEIER;
@@ -136,7 +137,8 @@ public class SelectCommandSystemTest extends AddressBookSystemTest {
         Model expectedModel = getModel();
 
         executeCommand(command);
-        assertApplicationDisplaysExpected(command, expectedResultMessage, expectedModel);
+        assertApplicationDisplaysExpected(
+            autoComplete(command, expectedModel.getFilteredPersonList()), expectedResultMessage, expectedModel);
         assertSelectedCardUnchanged();
         assertCommandBoxShowsErrorStyle();
         assertStatusBarUnchanged();


### PR DESCRIPTION
## Auto-complete an error command
When a command is invalid, auto-complete will try to parse it and complete it in the correct way.
- fill in fields that is not been inputed by the user. (add, edit)
- remove non-digit characters when an index is expected. (delete, export, select)
- try to find the position of the delimiter when it cannot be found. (export)
- trim unnecessary white spaces.
- try to guess what command is user inputting when the command word is invalid.
- complete the command when the prefix of a certain command is inputted.

The auto-completed command will replace the original command input in the command box